### PR TITLE
update fill and clone commands in line with type hint refactor

### DIFF
--- a/mcipc/rcon/je/commands/clone.py
+++ b/mcipc/rcon/je/commands/clone.py
@@ -1,14 +1,14 @@
 """Implementation of the clone command."""
 
 from mcipc.rcon.client import Client
-from mcipc.rcon import CloneMode, MaskMode
-from mcipc.rcon.types import Vec3 as Vec3Hint
+from mcipc.rcon.types import Vec3, CloneMode, MaskMode
+from mcipc.rcon import MaskMode as MaskModeType
 
 
 __all__ = ['clone']
 
 
-def clone(self: Client, begin: Vec3Hint, end: Vec3Hint, destination: Vec3Hint, *,
+def clone(self: Client, begin: Vec3, end: Vec3, destination: Vec3, *,
           mask_mode: MaskMode = None,
           filter: str = None,   # pylint: disable=W0622
           clone_mode: CloneMode = None) -> str:
@@ -17,9 +17,9 @@ def clone(self: Client, begin: Vec3Hint, end: Vec3Hint, destination: Vec3Hint, *
     args = ['clone', begin, end, destination]
 
     if mask_mode is not None:
-        args.append(mask_mode := MaskMode(mask_mode))
+        args.append(mask_mode := MaskModeType(mask_mode))
 
-        if mask_mode == str(MaskMode.FILTERED):
+        if mask_mode == str(MaskModeType.FILTERED):
             if filter is None:
                 raise ValueError('Missing filter.')
 

--- a/mcipc/rcon/je/commands/clone.py
+++ b/mcipc/rcon/je/commands/clone.py
@@ -1,13 +1,14 @@
 """Implementation of the clone command."""
 
 from mcipc.rcon.client import Client
-from mcipc.rcon.types import CloneMode, MaskMode, Vec3
+from mcipc.rcon import CloneMode, MaskMode
+from mcipc.rcon.types import Vec3 as Vec3Hint
 
 
 __all__ = ['clone']
 
 
-def clone(self: Client, begin: Vec3, end: Vec3, destination: Vec3, *,
+def clone(self: Client, begin: Vec3Hint, end: Vec3Hint, destination: Vec3Hint, *,
           mask_mode: MaskMode = None,
           filter: str = None,   # pylint: disable=W0622
           clone_mode: CloneMode = None) -> str:
@@ -16,7 +17,7 @@ def clone(self: Client, begin: Vec3, end: Vec3, destination: Vec3, *,
     args = ['clone', begin, end, destination]
 
     if mask_mode is not None:
-        args.append(mask_mode := str(mask_mode))
+        args.append(mask_mode := MaskMode(mask_mode))
 
         if mask_mode == str(MaskMode.FILTERED):
             if filter is None:

--- a/mcipc/rcon/je/commands/fill.py
+++ b/mcipc/rcon/je/commands/fill.py
@@ -1,24 +1,24 @@
 """Implementation of the fill command."""
 
 from mcipc.rcon.client import Client
-from mcipc.rcon import FillMode
-from mcipc.rcon.types import Vec3 as Vec3Hint
+from mcipc.rcon import FillMode as FillModeType
+from mcipc.rcon.types import Vec3 as Vec3, FillMode
 
 
 __all__ = ['fill']
 
 
 # pylint: disable=C0103,R0913,W0622
-def fill(self: Client, from_: Vec3Hint, to: Vec3Hint, block: str,
+def fill(self: Client, from_: Vec3, to: Vec3, block: str,
          mode: FillMode = None, filter: str = None) -> str:
     """Fills all or parts of a region with a specific block."""
 
     command = ['fill', from_, to, block]
 
     if mode is not None:
-        command.append(mode := FillMode(mode))
+        command.append(mode := FillModeType(mode))
 
-        if filter is not None and mode == FillMode.REPLACE:
+        if filter is not None and mode == FillModeType.REPLACE:
             command.append(filter)
 
     return self.run(*command)

--- a/mcipc/rcon/je/commands/fill.py
+++ b/mcipc/rcon/je/commands/fill.py
@@ -1,14 +1,15 @@
 """Implementation of the fill command."""
 
 from mcipc.rcon.client import Client
-from mcipc.rcon.types import FillMode, Vec3
+from mcipc.rcon import FillMode
+from mcipc.rcon.types import Vec3 as Vec3Hint
 
 
 __all__ = ['fill']
 
 
 # pylint: disable=C0103,R0913,W0622
-def fill(self: Client, from_: Vec3, to: Vec3, block: str,
+def fill(self: Client, from_: Vec3Hint, to: Vec3Hint, block: str,
          mode: FillMode = None, filter: str = None) -> str:
     """Fills all or parts of a region with a specific block."""
 


### PR DESCRIPTION
I have worked out why I have issues with the latest mcipc.

Two commands I am using, fill and clone were not updated in the type hinting refactor.

This problem may exist in other commands but I don't have time to look at the moment.

I think it would be quite fun to set up a GitHub Actions continuous integration set of system tests to mitigate this kind of issue in future. I would be interested in contributing this if you are up for it.