### PR TITLE
support float coords in Vec3

### DIFF
--- a/mcipc/rcon/builder/types.py
+++ b/mcipc/rcon/builder/types.py
@@ -22,9 +22,9 @@ class Anchor(Enum):
 class Vec3(NamedTuple):
     """A 3D vector."""
 
-    x: int = 0
-    y: int = 0
-    z: int = 0
+    x: Union[int, float] = 0
+    y: Union[int, float] = 0
+    z: Union[int, float] = 0
 
     def __add__(self, other):
         return type(self)(self.x + other.x, self.y + other.y, self.z + other.z)
@@ -53,7 +53,7 @@ class Vec3(NamedTuple):
     @property
     def length(self):
         """Returns the length of the spatial diagonal."""
-        return sqrt(pow(self.dx, 2), pow(self.dy, 2), pow(self.dz, 2))
+        return sqrt(pow(self.dx, 2) + pow(self.dy, 2) + pow(self.dz, 2))
 
     @property
     def west(self):
@@ -76,7 +76,7 @@ class Vec3(NamedTuple):
         return self.z > 0
 
     @property
-    def donw(self):
+    def down(self):
         """Checks whether the vector points down."""
         return self.y < 0
 


### PR DESCRIPTION
The latest implementation of Vec3 is working really well and has allowed me to delete all of my custom vector support code.

Here is a minor change to Vec3 to support float coordinates.

Also fixed typos in properties `north`, `length`.

This change allows the following example, teleportation of a player 2.5 blocks north, maintaining the other dimensions precisely.

```
from mcipc.rcon.builder.types import Vec3, Direction
from mcipc.rcon.je import Client
from mcipc.rcon import TargetType
import re

# extract the double coords from a string of the form
#  "DispenserAD11 has the following entity data: \
#   [-2984.3695730161085d, 87.16610926093821d, 54.42824875967167d]"
regex_coord = re.compile(r"\[(-?\d+.?\d*)d, *(-?\d+.?\d*)d, *(-?\d+.?\d*)d\]")


with Client("localhost", 25901, passwd="xxx") as client:
    player = "TransformerScorn"
    data = client.data.get(TargetType.ENTITY, player, "Pos")
    match = regex_coord.search(data)
    loc = Vec3(float(match.group(1)), float(match.group(2)), float(match.group(3)))

    loc += Direction.NORTH.value * 2.5

    client.teleport(targets=player, location=loc)
```