### PR TITLE
add up and down directions to mktunnel

### DIFF
--- a/mcipc/rcon/builder/api.py
+++ b/mcipc/rcon/builder/api.py
@@ -1,6 +1,5 @@
 """Exposed API functions."""
 
-from mcipc.rcon.enumerations import FillMode
 from mcipc.rcon.builder.functions import check_xz_dir
 from mcipc.rcon.builder.functions import get_offset
 from mcipc.rcon.builder.functions import normalize
@@ -8,6 +7,7 @@ from mcipc.rcon.builder.functions import validate
 from mcipc.rcon.builder.item import Item
 from mcipc.rcon.builder.types import Anchor, Direction, Profile, Vec3
 from mcipc.rcon.client import Client
+from mcipc.rcon.enumerations import FillMode
 
 
 __all__ = ['mktunnel']
@@ -37,5 +37,5 @@ def mktunnel(client: Client, profile: Profile, start: Vec3, *,
             offset = get_offset(y, xz, direction, anchor)
             result = client.fill(
                 start + offset, end + offset, block, mode=mode, filter=filter
-                )
+            )
             print(result)

--- a/mcipc/rcon/builder/api.py
+++ b/mcipc/rcon/builder/api.py
@@ -1,5 +1,6 @@
 """Exposed API functions."""
 
+from mcipc.rcon.enumerations import FillMode
 from mcipc.rcon.builder.functions import check_xz_dir
 from mcipc.rcon.builder.functions import get_offset
 from mcipc.rcon.builder.functions import normalize
@@ -14,7 +15,8 @@ __all__ = ['mktunnel']
 
 def mktunnel(client: Client, profile: Profile, start: Vec3, *,
              end: Vec3 = None, direction: Direction = None, length: int = 1,
-             anchor: Anchor = Anchor.BOTTOM_RIGHT, default: Item = Item.AIR):
+             anchor: Anchor = Anchor.BOTTOM_RIGHT, default: Item = Item.AIR,
+             mode: FillMode = None, filter: str = None):
     """Creates a tunnel with the given profile."""
 
     start = Vec3(*start)    # Ensure Vec3 object.
@@ -33,5 +35,7 @@ def mktunnel(client: Client, profile: Profile, start: Vec3, *,
     for y, row in enumerate(profile):   # pylint: disable=C0103
         for xz, block in enumerate(row):    # pylint: disable=C0103
             offset = get_offset(y, xz, direction, anchor)
-            result = client.fill(start + offset, end + offset, block)
+            result = client.fill(
+                start + offset, end + offset, block, mode=mode, filter=filter
+                )
             print(result)

--- a/mcipc/rcon/builder/functions.py
+++ b/mcipc/rcon/builder/functions.py
@@ -58,7 +58,7 @@ def get_offset(y: int, xz: int, direction: Vec3, anchor: Anchor) -> Vec3:
         return Vec3(0, -y if top else y, -xz if left else xz)
 
     if direction.up:
-        return Vec3(+xz if left else -xz, 0, -y if top else y)
+        return Vec3(xz if left else -xz, 0, -y if top else y)
 
     if direction.down:
         return Vec3(xz if left else -xz, 0, y if top else -y)

--- a/mcipc/rcon/builder/functions.py
+++ b/mcipc/rcon/builder/functions.py
@@ -57,4 +57,10 @@ def get_offset(y: int, xz: int, direction: Vec3, anchor: Anchor) -> Vec3:
     if direction.west:
         return Vec3(0, -y if top else y, -xz if left else xz)
 
+    if direction.up:
+        return Vec3(+xz if left else -xz, 0, -y if top else y)
+
+    if direction.down:
+        return Vec3(xz if left else -xz, 0, y if top else -y)
+
     raise ValueError('Cannot determine offset.')


### PR DESCRIPTION
This allows you to use mktunnel to build towers too.

Up and Down are implemented as rotations about X axis for the North facing profile so that this code:
```
    p: Profile = [
        [Item.RED_WOOL.value, Item.AIR.value, Item.GREEN_WOOL.value],
        [Item.AIR.value, Item.AIR.value, Item.AIR.value],
        [Item.BLUE_WOOL.value, Item.AIR.value, Item.YELLOW_WOOL.value],
    ]
    clear: Profile = [[None] * 100] * 100

    mid = Vec3(0, 50, 0)

    # clear 100 * 100 * 100 centred on world_middle
    mktunnel(client, clear, Vec3(50, 0, -50), direction=Direction.UP, length=100)

    a = Anchor.TOP_LEFT
    mktunnel(client, p, mid, direction=Direction.NORTH, length=5, mode=FillMode.KEEP, anchor=a)
    mktunnel(client, p, mid, direction=Direction.SOUTH, length=5, mode=FillMode.KEEP, anchor=a)
    mktunnel(client, p, mid, direction=Direction.EAST, length=5, mode=FillMode.KEEP, anchor=a)
    mktunnel(client, p, mid, direction=Direction.WEST, length=5, mode=FillMode.KEEP, anchor=a)
    mktunnel(client, p, mid, direction=Direction.UP, length=5, mode=FillMode.KEEP, anchor=a)
    mktunnel(client, p, mid, direction=Direction.DOWN, length=5, mode=FillMode.KEEP, anchor=a)
```

Produces this:
![image](https://user-images.githubusercontent.com/964827/103447868-f3886e80-4c88-11eb-9a6e-62924fb0d39e.png)
