### PR TITLE
reflect requirement for python 3.9

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,6 +23,6 @@ version: 2
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: 3.9
   install:
     - requirements: requirements.txt

--- a/README.md
+++ b/README.md
@@ -7,22 +7,22 @@ A Minecraft inter-process communication API implementing the [RCON](http://wiki.
 ## News
 
 ### 2020-12-21 - mcipc-2.0
-Great news: `mcipc` is now available in version 2.  
-The version 2 update includes the outsourcing of the RCON protocol and client implementation into an [own project](https://github.com/conqp/rcon).  
-This allowes for the RCON library to be used independently of mcipc, e.g. for other games which support the RCON protocol.  
-Furthermore `mcipc`'s RCON client implementations have been overhauled. They now provide functions to interact with the respective server.  
+Great news: `mcipc` is now available in version 2.
+The version 2 update includes the outsourcing of the RCON protocol and client implementation into an [own project](https://github.com/conqp/rcon).
+This allowes for the RCON library to be used independently of mcipc, e.g. for other games which support the RCON protocol.
+Furthermore `mcipc`'s RCON client implementations have been overhauled. They now provide functions to interact with the respective server.
 It was therefor necessary to not have one implementation of `mcipc.rcon.Client`, but three:
 
 *  `mcipc.rcon.be.Client` Client for Bedrock Edition servers.
 *  `mcipc.rcon.ee.Client` Client for Education Edition servers.
 *  `mcipc.rcon.je.Client` Client for Java Edition servers.
 
-To provide some backwards compatibility, the `mcipc.rcon.Client` is now an alias for `mcipc.rcon.je.Client`.  
+To provide some backwards compatibility, the `mcipc.rcon.Client` is now an alias for `mcipc.rcon.je.Client`.
 You'll find a full documentation of each client's capabilities, i.e. methods in the [documentation](https://mcipc.readthedocs.io/en/latest).
 
 ## Requirements
-`mcipc` requires Python 3.8 or higher.  
-It also depends on [rcon](https://github.com/conqp/rcon) which has been split from this project.  
+`mcipc` requires Python 3.9 or higher.
+It also depends on [rcon](https://github.com/conqp/rcon) which has been split from this project.
 If you install `mcicp` via `pip`, it will automatically be installed as a dependency.
 
 ## Documentation
@@ -35,7 +35,7 @@ Install mcipc from the [AUR](https://aur.archlinux.org/packages/python-mcipc/) o
     pip install mcipc
 
 ### Query protocol
-The `Query` protcol is used to query a Minecraft server for server information.  
+The `Query` protcol is used to query a Minecraft server for server information.
 The Minecraft query protocol has two query modes: *basic stats* and *full stats*.
 
 ```python

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,4 +12,4 @@ Otherwise you can install `mcipc` via pip:
 Requirements
 ============
 
-`mcipc` requires Python 3.8 or higher.
+`mcipc` requires Python 3.9 or higher.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     setup_requires=['setuptools_scm'],
     author='Richard Neumann',
     author_email='mail@richard-neumann.de',
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=[
         'mcipc',
         'mcipc.query',


### PR DESCRIPTION
the project now uses 3.9 features - changing setup.py and documentation to reflect this

(my editor also removed trailing whitespace in README.md)