### PR TITLE
add global lock to Client run

### DIFF
--- a/mcipc/rcon/client.py
+++ b/mcipc/rcon/client.py
@@ -1,11 +1,14 @@
 """Minecraft-specific client."""
 
-from rcon import source
+from threading import Lock
 
 from mcipc.rcon.functions import str_until_none
 
+from rcon import source
 
-__all__ = ['Client']
+__all__ = ["Client"]
+
+LOCK = Lock()
 
 
 class Client(source.Client):
@@ -13,4 +16,6 @@ class Client(source.Client):
 
     def run(self, command: str, *arguments: str) -> str:
         """Runs the command with additional checks."""
-        return super().run(*str_until_none(command, *arguments))
+
+        with LOCK:
+            return super().run(*str_until_none(command, *arguments))


### PR DESCRIPTION
For discussion.

This fixes the issue of multiple threads in a process getting the wrong responses from Client.run(). It provides a global lock to make sure all send receive operations are atomic.

See problem description here: https://github.com/conqp/rcon/issues/13

It does not fix multiple processes talking to the same RCON - these will still experience cross talk.